### PR TITLE
feat - 아이템 목록 보여줄 테이블뷰, 셀, 뷰모델 구현과 합체

### DIFF
--- a/JangBiBBal.xcodeproj/project.pbxproj
+++ b/JangBiBBal.xcodeproj/project.pbxproj
@@ -19,6 +19,24 @@
 		3D0B864B2822C5AE000EA380 /* TagCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B864A2822C5AD000EA380 /* TagCollectionView.swift */; };
 		3D0B864E2822C66C000EA380 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3D0B864D2822C66C000EA380 /* SnapKit */; };
 		3D0B86512822C6D8000EA380 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86502822C6D8000EA380 /* Constant.swift */; };
+		3D0B86542822DE27000EA380 /* TagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86532822DE27000EA380 /* TagCell.swift */; };
+		3D0B865B282406A1000EA380 /* TagCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B865A282406A1000EA380 /* TagCellModel.swift */; };
+		3D0B865D2824073E000EA380 /* TagCollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B865C2824073E000EA380 /* TagCollectionViewModel.swift */; };
+		3D0B866028241056000EA380 /* TagCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B865F28241056000EA380 /* TagCellData.swift */; };
+		3D0B8663282414A6000EA380 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B8662282414A6000EA380 /* UIColor.swift */; };
+		3D0B8665282423AC000EA380 /* ShoppingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B8664282423AC000EA380 /* ShoppingTableView.swift */; };
+		3D0B86682824CFE9000EA380 /* ShoppingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86672824CFE9000EA380 /* ShoppingResponse.swift */; };
+		3D0B866C2824D25E000EA380 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 3D0B866B2824D25E000EA380 /* Alamofire */; };
+		3D0B866E2824D576000EA380 /* ShoppingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B866D2824D576000EA380 /* ShoppingAPI.swift */; };
+		3D0B86712824D65C000EA380 /* NaverAPIKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86702824D65C000EA380 /* NaverAPIKeys.swift */; };
+		3D0B86732824D6B8000EA380 /* ShoppingNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86722824D6B8000EA380 /* ShoppingNetworkManager.swift */; };
+		3D0B86752824DFAA000EA380 /* ShoppingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86742824DFAA000EA380 /* ShoppingTableViewCell.swift */; };
+		3D0B86782824FA28000EA380 /* CustomObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86772824FA28000EA380 /* CustomObservable.swift */; };
+		3D0B867A2824FCE1000EA380 /* ShoppingTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B86792824FCE1000EA380 /* ShoppingTableViewModel.swift */; };
+		3D0B867D2825765E000EA380 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B867C2825765E000EA380 /* String.swift */; };
+		3D0B868028257809000EA380 /* ShoppingCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B867F28257809000EA380 /* ShoppingCellViewModel.swift */; };
+		3D0B868228257CF6000EA380 /* ShoppingCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0B868128257CF6000EA380 /* ShoppingCellModel.swift */; };
+		3D0B868528257E26000EA380 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3D0B868428257E26000EA380 /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +72,22 @@
 		3D0B86482821765F000EA380 /* NaviTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaviTitle.swift; sourceTree = "<group>"; };
 		3D0B864A2822C5AD000EA380 /* TagCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionView.swift; sourceTree = "<group>"; };
 		3D0B86502822C6D8000EA380 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		3D0B86532822DE27000EA380 /* TagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCell.swift; sourceTree = "<group>"; };
+		3D0B865A282406A1000EA380 /* TagCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellModel.swift; sourceTree = "<group>"; };
+		3D0B865C2824073E000EA380 /* TagCollectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionViewModel.swift; sourceTree = "<group>"; };
+		3D0B865F28241056000EA380 /* TagCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellData.swift; sourceTree = "<group>"; };
+		3D0B8662282414A6000EA380 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		3D0B8664282423AC000EA380 /* ShoppingTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingTableView.swift; sourceTree = "<group>"; };
+		3D0B86672824CFE9000EA380 /* ShoppingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingResponse.swift; sourceTree = "<group>"; };
+		3D0B866D2824D576000EA380 /* ShoppingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingAPI.swift; sourceTree = "<group>"; };
+		3D0B86702824D65C000EA380 /* NaverAPIKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaverAPIKeys.swift; sourceTree = "<group>"; };
+		3D0B86722824D6B8000EA380 /* ShoppingNetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingNetworkManager.swift; sourceTree = "<group>"; };
+		3D0B86742824DFAA000EA380 /* ShoppingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingTableViewCell.swift; sourceTree = "<group>"; };
+		3D0B86772824FA28000EA380 /* CustomObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomObservable.swift; sourceTree = "<group>"; };
+		3D0B86792824FCE1000EA380 /* ShoppingTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingTableViewModel.swift; sourceTree = "<group>"; };
+		3D0B867C2825765E000EA380 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		3D0B867F28257809000EA380 /* ShoppingCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCellViewModel.swift; sourceTree = "<group>"; };
+		3D0B868128257CF6000EA380 /* ShoppingCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingCellModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,7 +95,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D0B868528257E26000EA380 /* Kingfisher in Frameworks */,
 				3D0B864E2822C66C000EA380 /* SnapKit in Frameworks */,
+				3D0B866C2824D25E000EA380 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,7 +176,9 @@
 		3D0B8641282174B6000EA380 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				3D0B86522822DE1D000EA380 /* Cells */,
 				3D0B864A2822C5AD000EA380 /* TagCollectionView.swift */,
+				3D0B8664282423AC000EA380 /* ShoppingTableView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -148,6 +186,9 @@
 		3D0B8642282174BA000EA380 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				3D0B867E282577E2000EA380 /* Cells */,
+				3D0B865C2824073E000EA380 /* TagCollectionViewModel.swift */,
+				3D0B86792824FCE1000EA380 /* ShoppingTableViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -155,7 +196,10 @@
 		3D0B8643282174C3000EA380 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				3D0B865E28241044000EA380 /* DummyData */,
 				3D0B864728217652000EA380 /* Navigation */,
+				3D0B865A282406A1000EA380 /* TagCellModel.swift */,
+				3D0B868128257CF6000EA380 /* ShoppingCellModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -163,6 +207,10 @@
 		3D0B8644282174C7000EA380 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				3D0B866F2824D648000EA380 /* Secret */,
+				3D0B86692824D00B000EA380 /* Entity */,
+				3D0B866D2824D576000EA380 /* ShoppingAPI.swift */,
+				3D0B86722824D6B8000EA380 /* ShoppingNetworkManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -178,9 +226,61 @@
 		3D0B864F2822C6C7000EA380 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				3D0B866128241493000EA380 /* Extension */,
 				3D0B86502822C6D8000EA380 /* Constant.swift */,
+				3D0B86772824FA28000EA380 /* CustomObservable.swift */,
 			);
 			path = Configuration;
+			sourceTree = "<group>";
+		};
+		3D0B86522822DE1D000EA380 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B86532822DE27000EA380 /* TagCell.swift */,
+				3D0B86742824DFAA000EA380 /* ShoppingTableViewCell.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		3D0B865E28241044000EA380 /* DummyData */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B865F28241056000EA380 /* TagCellData.swift */,
+			);
+			path = DummyData;
+			sourceTree = "<group>";
+		};
+		3D0B866128241493000EA380 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B8662282414A6000EA380 /* UIColor.swift */,
+				3D0B867C2825765E000EA380 /* String.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		3D0B86692824D00B000EA380 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B86672824CFE9000EA380 /* ShoppingResponse.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
+		3D0B866F2824D648000EA380 /* Secret */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B86702824D65C000EA380 /* NaverAPIKeys.swift */,
+			);
+			path = Secret;
+			sourceTree = "<group>";
+		};
+		3D0B867E282577E2000EA380 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				3D0B867F28257809000EA380 /* ShoppingCellViewModel.swift */,
+			);
+			path = Cells;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -201,6 +301,8 @@
 			name = JangBiBBal;
 			packageProductDependencies = (
 				3D0B864D2822C66C000EA380 /* SnapKit */,
+				3D0B866B2824D25E000EA380 /* Alamofire */,
+				3D0B868428257E26000EA380 /* Kingfisher */,
 			);
 			productName = JangBiBBal;
 			productReference = 3D0B860E2820C605000EA380 /* JangBiBBal.app */;
@@ -276,6 +378,8 @@
 			mainGroup = 3D0B86052820C605000EA380;
 			packageReferences = (
 				3D0B864C2822C66C000EA380 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				3D0B866A2824D25E000EA380 /* XCRemoteSwiftPackageReference "Alamofire" */,
+				3D0B868328257E26000EA380 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 3D0B860F2820C605000EA380 /* Products */;
 			projectDirPath = "";
@@ -319,11 +423,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D0B86752824DFAA000EA380 /* ShoppingTableViewCell.swift in Sources */,
+				3D0B86782824FA28000EA380 /* CustomObservable.swift in Sources */,
+				3D0B867D2825765E000EA380 /* String.swift in Sources */,
+				3D0B866028241056000EA380 /* TagCellData.swift in Sources */,
+				3D0B86542822DE27000EA380 /* TagCell.swift in Sources */,
 				3D0B86462821750D000EA380 /* MainViewController.swift in Sources */,
+				3D0B86712824D65C000EA380 /* NaverAPIKeys.swift in Sources */,
+				3D0B86732824D6B8000EA380 /* ShoppingNetworkManager.swift in Sources */,
+				3D0B867A2824FCE1000EA380 /* ShoppingTableViewModel.swift in Sources */,
+				3D0B865B282406A1000EA380 /* TagCellModel.swift in Sources */,
+				3D0B866E2824D576000EA380 /* ShoppingAPI.swift in Sources */,
+				3D0B865D2824073E000EA380 /* TagCollectionViewModel.swift in Sources */,
 				3D0B86122820C605000EA380 /* AppDelegate.swift in Sources */,
 				3D0B864B2822C5AE000EA380 /* TagCollectionView.swift in Sources */,
+				3D0B8663282414A6000EA380 /* UIColor.swift in Sources */,
 				3D0B86492821765F000EA380 /* NaviTitle.swift in Sources */,
+				3D0B8665282423AC000EA380 /* ShoppingTableView.swift in Sources */,
 				3D0B86142820C605000EA380 /* SceneDelegate.swift in Sources */,
+				3D0B86682824CFE9000EA380 /* ShoppingResponse.swift in Sources */,
+				3D0B868228257CF6000EA380 /* ShoppingCellModel.swift in Sources */,
+				3D0B868028257809000EA380 /* ShoppingCellViewModel.swift in Sources */,
 				3D0B86512822C6D8000EA380 /* Constant.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -666,6 +786,22 @@
 				minimumVersion = 5.0.1;
 			};
 		};
+		3D0B866A2824D25E000EA380 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.6.1;
+			};
+		};
+		3D0B868328257E26000EA380 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -673,6 +809,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3D0B864C2822C66C000EA380 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		3D0B866B2824D25E000EA380 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0B866A2824D25E000EA380 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		3D0B868428257E26000EA380 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D0B868328257E26000EA380 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/JangBiBBal/MainViewController.swift
+++ b/JangBiBBal/MainViewController.swift
@@ -12,25 +12,109 @@ import SnapKit
 class MainViewController : UIViewController {
     
     let tagCV = TagCollectionView()
+    let tagCVVM = TagCollectionViewModel()
+    
+    let shoppingTV = ShoppingTableView()
+    let shoppingTVVM =  ShoppingTableViewModel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setAttribute()
         setLayout()
+        setupData()
+        setTableView()
     }
+    
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//
+//        let cvIndexPath = IndexPath(row: 0, section: 0)
+//        tagCV.selectItem(at: cvIndexPath, animated: false, scrollPosition: .left)
+//    }
 }
 
 extension MainViewController {
     private func setAttribute() {
         self.title = NaviTitle.mainTitle
         view.backgroundColor = .white
+        
+        tagCV.delegate = self
+        tagCV.dataSource = self
     }
     private func setLayout() {
-        [tagCV].forEach { self.view.addSubview($0) }
+        [tagCV,shoppingTV].forEach { self.view.addSubview($0) }
         tagCV.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalToSuperview().multipliedBy(0.08)
         }
+        shoppingTV.snp.makeConstraints {
+            $0.top.equalTo(tagCV.snp.bottom).offset(8)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    private func setupData() {
+        shoppingTVVM.fetchData("그립")
+    }
+    private func setTableView() {
+        shoppingTV.delegate = self
+        shoppingTV.dataSource = self
+        shoppingTV.bind(shoppingTVVM)
+    }
+}
+
+
+extension MainViewController : UICollectionViewDelegate, UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return tagCVVM.numberOftagArr
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TagCell.registerID, for: indexPath) as? TagCell else {
+            return UICollectionViewCell()
+        }
+        let tagName = tagCVVM.gettagName(index: indexPath.row)
+        let tagBackgroundColor = tagCVVM.gettagBackgroundColor(index: indexPath.row)
+        cell.setData(tagName)
+        cell.setBackgroundColor(tagBackgroundColor)
+        if indexPath.row == tagCVVM.defaultItemIdx {
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: .init())
+        }
+        cell.isSelected = indexPath.row == tagCVVM.defaultItemIdx
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let query = tagCVVM.getSearchQueryFromTag(index: indexPath.row)
+        shoppingTVVM.fetchData(query)
+    }
+}
+
+extension MainViewController : UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let tagName = tagCVVM.gettagName(index: indexPath.row).tagName
+        let cellWidth = tagName.size(withAttributes: [NSAttributedString.Key.font : UIFont.systemFont(ofSize: 12)]).width + 25
+        let cellHeight = collectionView.frame.height * 0.6
+        let cellSize = CGSize(width: cellWidth, height: cellHeight)
+        
+        return cellSize
+    }
+}
+
+extension MainViewController : UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return shoppingTVVM.storage.value.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ShoppingTableViewCell.registerID, for: indexPath) as? ShoppingTableViewCell else {
+            return UITableViewCell()
+        }
+        let shoppingItem  = shoppingTVVM.storage.value[indexPath.row]
+        
+        cell.setData(shoppingItem)
+        return cell
     }
 }

--- a/JangBiBBal/Model/ShoppingCellModel.swift
+++ b/JangBiBBal/Model/ShoppingCellModel.swift
@@ -1,0 +1,16 @@
+//
+//  ShoppingCellModel.swift
+//  JangBiBBal
+//
+//  Created by miori Lee on 2022/05/07.
+//
+
+import Foundation
+
+struct ShoppingCellModel {
+    let title : String?
+    let link : URL?
+    let image : URL?
+    let lprice : String
+    let brand : String
+}

--- a/JangBiBBal/View/Cells/ShoppingTableViewCell.swift
+++ b/JangBiBBal/View/Cells/ShoppingTableViewCell.swift
@@ -1,0 +1,80 @@
+//
+//  ShoppingTableViewCell.swift
+//  JangBiBBal
+//
+//  Created by miori Lee on 2022/05/06.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+import Kingfisher
+
+class ShoppingTableViewCell : UITableViewCell {
+    
+    static let registerID = "\(ShoppingTableViewCell.self)"
+    
+    let itemImageView = UIImageView()
+    let itemNameLabel = UILabel()
+    let itemBrandLabel = UILabel()
+    let itemPriceLabel = UILabel()
+    
+    let cellViewModel = ShoppingCellViewModel()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setAttribute()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setAttribute() {
+        itemImageView.contentMode = .scaleToFill
+        itemImageView.backgroundColor = .white
+        itemNameLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        itemBrandLabel.font = .systemFont(ofSize: 11)
+        itemBrandLabel.textColor = .darkGray
+        [itemNameLabel,itemBrandLabel].forEach {$0.numberOfLines = 0 }
+        itemPriceLabel.font = .systemFont(ofSize: 12, weight: .light)
+    }
+    
+    private func setLayout() {
+        [itemImageView,itemNameLabel,itemBrandLabel,itemPriceLabel].forEach {
+            contentView.addSubview($0)
+        }
+        itemImageView.snp.makeConstraints {
+            $0.top.equalTo(itemNameLabel)
+            $0.leading.equalToSuperview().offset(20)
+            $0.width.equalTo(contentView).multipliedBy(0.15)
+            $0.height.equalTo(itemImageView.snp.width)//.multipliedBy(1.3)
+        }
+        itemNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.leading.equalTo(itemImageView.snp.trailing).offset(17.5)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        itemBrandLabel.snp.makeConstraints {
+            $0.top.equalTo(itemNameLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalTo(itemNameLabel)
+        }
+        itemPriceLabel.snp.makeConstraints {
+            $0.top.equalTo(itemBrandLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalTo(itemNameLabel)
+            $0.bottom.equalToSuperview().inset(12)
+        }
+        
+    }
+    
+    func setData(_ model : ShoppingItems) {
+        let _model = cellViewModel.changeDataFormat(model)
+        itemImageView.kf.setImage(with: _model.image)
+        itemNameLabel.text = _model.title
+        itemBrandLabel.text = _model.brand
+        itemPriceLabel.text = _model.lprice
+    }
+    
+}

--- a/JangBiBBal/View/ShoppingTableView.swift
+++ b/JangBiBBal/View/ShoppingTableView.swift
@@ -1,0 +1,39 @@
+//
+//  ShoppingTableView.swift
+//  JangBiBBal
+//
+//  Created by miori Lee on 2022/05/06.
+//
+
+import Foundation
+import UIKit
+
+class ShoppingTableView : UITableView {
+    
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: .plain)
+        
+        setTableView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setTableView() {
+        self.backgroundColor = .white
+        self.register(ShoppingTableViewCell.self, forCellReuseIdentifier: ShoppingTableViewCell.registerID)
+        self.rowHeight = UITableView.automaticDimension
+        self.estimatedRowHeight = ScreenConstant.deviceHeight * 0.12
+        self.separatorStyle = .singleLine
+    }
+    
+    func bind(_ viewModel : ShoppingTableViewModel) {
+        viewModel.storage.bind { [weak self] _ in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.reloadData()
+            }
+        }
+    }
+}

--- a/JangBiBBal/ViewModel/Cells/ShoppingCellViewModel.swift
+++ b/JangBiBBal/ViewModel/Cells/ShoppingCellViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  ShoppingCellViewModel.swift
+//  JangBiBBal
+//
+//  Created by miori Lee on 2022/05/07.
+//
+
+import Foundation
+
+class ShoppingCellViewModel {
+    
+    func changeDataFormat(_ model : ShoppingItems) -> ShoppingCellModel {
+        
+        let image = URL(string: model.image)
+        let link = URL(string: model.link)
+        let title  = model.title.deleteMarkDown()
+        let brand = model.brand.isEmpty ? " " : "🏛 브랜드 : \(model.brand)"
+        let lprice = "💸 \(model.lprice) ~ "
+        
+        return ShoppingCellModel(title: title, link: link, image: image, lprice: lprice, brand: brand)
+        
+    }
+}

--- a/JangBiBBal/ViewModel/ShoppingTableViewModel.swift
+++ b/JangBiBBal/ViewModel/ShoppingTableViewModel.swift
@@ -1,0 +1,37 @@
+//
+//  ShoppingTableViewModel.swift
+//  JangBiBBal
+//
+//  Created by miori Lee on 2022/05/06.
+//
+
+import Foundation
+
+class ShoppingTableViewModel : ObservableVMProtocol {
+    
+    typealias T = ShoppingItems
+    
+    var errorMessage: Observable<String?> = Observable(nil)
+    var error: Observable<Bool> =  Observable(false)
+    
+    var shoppingNetwork : ShoppingNetworkManager
+    var storage: Observable<[ShoppingItems]> = Observable([])
+    
+    init(networkManager : ShoppingNetworkManager = ShoppingNetworkManager()) {
+        self.shoppingNetwork = networkManager
+    }
+    
+    func fetchData(_ query : String) {
+        self.shoppingNetwork.getItmes("크로스핏 \(query)") { response in
+            let observable = Observable(response)
+            //value로 넘겨주기
+            self.storage.value = observable.value
+            //print("storage : \(self.storage.value)")
+        }
+    }
+    
+    func setError(_ message: String) {
+        //
+    }
+}
+


### PR DESCRIPTION
# 개요
<!-- PR과 관련된 링크 추가. -->
- 🔗  JIRA 이슈 링크 : https://miori.atlassian.net/browse/STB-13
- 📝  기획서 링크 : 

### 📌 작업 완료 기한
- 2022/05/09

# 수정사항

## 수정 내용
<!-- 수정된 코드/UI에 대해서. -->
- 아이템 목록 보여줄 테이블 뷰 셀 모델 구현 (response model 과 다른점은 url을 string 이 아닌 url로 받는다는 점)
- response model -> cell model 로 변경해주는 셀 뷰모델 구현
- 테이블 뷰 셀 구현
- 테이블 뷰 뷰 모델 구현 (네트워크롤 통해 데이터 변함을 감지하기 위함)
- 테이블뷰와 뷰모델 바인딩 (값이 변했을 때 reloadData)
- 뷰컨트롤러에서 합체

### 미리보기
<!-- 작업 후 UI 수정된 UI -->
📱|작업 후
---|---
iPhone13|<img width="290" alt="스크린샷 2022-05-09 오후 11 39 44" src="https://user-images.githubusercontent.com/46439995/167434356-6098add7-8a7a-4c99-951f-dd98d0c21f38.png">


# 확인사항
<!-- 동작, 화면 표시 등 필요가 있을 경우 작성합니다. -->
- [x] 동작 확인 
